### PR TITLE
Support dos2unix/unix2dos as alternate programs

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -214,7 +214,7 @@ maintainer-clean-local:
 	advd2 man < $(srcdir)/$< > $@
 
 %.txt : %.d
-	advd2 txt < $(srcdir)/$< | todos > $@
+	advd2 txt < $(srcdir)/$< | $(TODOS) > $@
 
 %.html : %.d
 	advd2 html < $(srcdir)/$< > $@
@@ -225,19 +225,19 @@ maintainer-clean-local:
 # Archives
 
 README: doc/readme.txt
-	cat $< | fromdos > $@
+	cat $< | $(FROMDOS) > $@
 
 AUTHORS: doc/authors.txt
-	cat $< | fromdos > $@
+	cat $< | $(FROMDOS) > $@
 
 INSTALL: doc/install.txt
-	cat $< | fromdos > $@
+	cat $< | $(FROMDOS) > $@
 
 HISTORY: doc/history.txt
-	cat $< | fromdos > $@
+	cat $< | $(FROMDOS) > $@
 
 doc/copying.txt: COPYING
-	cat $< | todos > $@
+	cat $< | $(TODOS) > $@
 
 check-local: ./advzip$(EXEEXT) test/test.lst
 	@cp $(srcdir)/test/archive.zip .
@@ -300,7 +300,7 @@ check-local: ./advzip$(EXEEXT) test/test.lst
 	$(TESTENV) ./advpng$(EXEEXT) -L basn2c08.png basn3p01.png basn3p02.png basn3p04.png basn3p08.png basn6a08.png basn6a04.png >> check.lst
 	$(TESTENV) ./advdef$(EXEEXT) -f -z -4 basn2c08.png basn3p01.png basn3p02.png basn3p04.png basn3p08.png basn6a08.png basn6a04.png
 	$(TESTENV) ./advpng$(EXEEXT) -L basn2c08.png basn3p01.png basn3p02.png basn3p04.png basn3p08.png basn6a08.png basn6a04.png >> check.lst
-	cat check.lst | fromdos | cmp $(srcdir)/test/test.lst
+	cat check.lst | $(FROMDOS) | cmp $(srcdir)/test/test.lst
 	@echo Success!
 
 DISTDOS_ROOT = \

--- a/configure.ac
+++ b/configure.ac
@@ -18,6 +18,8 @@ AC_CHECK_PROGS(GROFF, groff)
 AC_CHECK_PROGS(COL, col)
 AC_CHECK_PROG([VALGRIND],[valgrind],[valgrind --leak-check=full --track-fds=yes --error-exitcode=1],[])
 AC_CHECK_PROG([WINE],[wine],[wine],[])
+AC_CHECK_PROGS(FROMDOS, fromdos dos2unix)
+AC_CHECK_PROGS(TODOS, todos unix2dos)
 
 dnl Checks for libraries.
 AC_SYS_LARGEFILE


### PR DESCRIPTION
Some systems don't have fromdos/todos and these are drop-in replacement
for these use cases.
